### PR TITLE
emoji-chars 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# emoji-chars [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/emoji-chars.svg)](https://www.npmjs.com/package/emoji-chars) [![Downloads](https://img.shields.io/npm/dt/emoji-chars.svg)](https://www.npmjs.com/package/emoji-chars) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# emoji-chars
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/emoji-chars.svg)](https://www.npmjs.com/package/emoji-chars) [![Downloads](https://img.shields.io/npm/dt/emoji-chars.svg)](https://www.npmjs.com/package/emoji-chars) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Get the emoji chars as array.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emoji-chars",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Get the emoji chars as array.",
   "main": "lib/index.js",
   "directories": {
@@ -35,6 +35,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
